### PR TITLE
Swift 3.0 issues

### DIFF
--- a/Example/StravaSwift/ActivitiesViewController.swift
+++ b/Example/StravaSwift/ActivitiesViewController.swift
@@ -21,12 +21,15 @@ class ActivitiesViewController: UITableViewController {
 
 extension ActivitiesViewController {
     
-    fileprivate func update(params: [String: String]? = nil) {
-        try? StravaClient.sharedInstance.request(Router.athleteActivities(params: params)) { [weak self] (activities: [Activity]?) in
+    fileprivate func update(params: Router.Params = nil) {
+        try? StravaClient.sharedInstance.request(Router.athleteActivities(params: params), result: { [weak self] (activities: [Activity]?) in
             guard let `self` = self, let activities = activities else { return }
             self.activities = activities
             self.tableView?.reloadData()
-        }
+        }, failure: { (error: NSError) in
+            debugPrint(error)
+        })
+
     }
 }
 

--- a/Example/StravaSwift/AthleteViewController.swift
+++ b/Example/StravaSwift/AthleteViewController.swift
@@ -44,9 +44,11 @@ class AthleteViewController: UIViewController {
 extension AthleteViewController {
     
     func update() {
-        try? StravaClient.sharedInstance.request(Router.athlete) { [weak self] (athlete: Athlete?) in
+        try? StravaClient.sharedInstance.request(Router.athlete, result: { [weak self] (athlete: Athlete?) in
             guard let `self` = self, let athlete = athlete else { return }
             self.athlete = athlete
-        }
+        }, failure: { (error: NSError) in
+            debugPrint(error)
+        })
     }
 }

--- a/Example/StravaSwift/ConnectViewController.swift
+++ b/Example/StravaSwift/ConnectViewController.swift
@@ -32,8 +32,7 @@ class ConnectViewController: UIViewController {
                                                object: nil)
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
+    deinit {
         NotificationCenter.default.removeObserver(self)
     }
     

--- a/StravaSwift/StravaClient.swift
+++ b/StravaSwift/StravaClient.swift
@@ -79,10 +79,13 @@ extension StravaClient {
      Opens the Strava OAuth web page in mobile Safari for the user to authorize the application.
      **/
     public func authorize(sender: UIViewController? = nil) {
-        safariViewController = SFSafariViewController(url: Router.authorizationUrl)
-        if let safariViewController = safariViewController {
-            (sender ?? currentViewController)?.present(safariViewController, animated: true, completion: nil)
-        }
+        
+        UIApplication.shared.openURL(Router.authorizationUrl)
+
+//        safariViewController = SFSafariViewController(url: Router.authorizationUrl)
+//        if let safariViewController = safariViewController {
+//            (sender ?? currentViewController)?.present(safariViewController, animated: true, completion: nil)
+//        }
     }
     
     /**


### PR DESCRIPTION
Fixes issues with the Sample App after the recent API changes and tests all requests in the Sample App are working.

I had to revert to using the old authentication method (full standalone browser instead of SFSafariVC) due to display issues in the sample app. 

I agree that the SFSafariVC is a better approach, but it will require more changes to the Sample App to get it working. I might have a chance to work on that later, but I wanted to see what you thought about creating a `StravaAuthDelegate` that is registered on the singleton. This delegate would be notified by the singleton when the auth succeeds (with the token) or fails (with the error).