### PR TITLE
Fix for upload function

### DIFF
--- a/Sources/StravaSwift/StravaClient.swift
+++ b/Sources/StravaSwift/StravaClient.swift
@@ -320,7 +320,7 @@ extension StravaClient {
         guard let url = try? URLRequest.asURLRequest() else { return }
 
         Alamofire.upload(multipartFormData: { multipartFormData in
-            multipartFormData.append(upload.file, withName: "\(upload.name ?? "default").\(upload.dataType)")
+            multipartFormData.append(upload.file, withName: "file", fileName: "\(upload.name ?? "default").\(upload.dataType)", mimeType: "octet/stream")
             for (key, value) in upload.params {
                 if let value = value as? String {
                     multipartFormData.append(value.data(using: .utf8)!, withName: key)


### PR DESCRIPTION
> Hi, For current Strava API, /upload API needs file data to be named "file" in multipart Data. So here is my fix that makes my project working now. Cheers Sebastien

This fix is not mine, it was implemented by wizapp in #13 . Version 1.0.1 doesn't work, but implementing this change lets me successfully upload .gtx files.