### PR TITLE
Change Router typealias Id from Int to String

### DIFF
--- a/Sources/StravaSwift/Activity.swift
+++ b/Sources/StravaSwift/Activity.swift
@@ -114,7 +114,7 @@ public final class Activity: Strava {
         flagged = json["flagged"].bool
         workoutType = json["workout_type"].strava(WorkoutType.self)
         gear = json["gear"].strava(Gear.self)
-        gearID = json["gear_id].string
+        gearID = json["gear_id"].string
         averageSpeed = json["average_speed"].double
         maxSpeed = json["max_speed"].double
         calories = json["calories"].double

--- a/Sources/StravaSwift/Activity.swift
+++ b/Sources/StravaSwift/Activity.swift
@@ -57,6 +57,7 @@ public final class Activity: Strava {
     public let flagged: Bool?
     public let workoutType: WorkoutType?
     public let gear: Gear?
+    public let gearID: String?
     public let averageSpeed: Speed?
     public let maxSpeed: Speed?
     public let calories: Double?
@@ -113,6 +114,7 @@ public final class Activity: Strava {
         flagged = json["flagged"].bool
         workoutType = json["workout_type"].strava(WorkoutType.self)
         gear = json["gear"].strava(Gear.self)
+        gearID = json["gear_id].string
         averageSpeed = json["average_speed"].double
         maxSpeed = json["max_speed"].double
         calories = json["calories"].double

--- a/Sources/StravaSwift/Router.swift
+++ b/Sources/StravaSwift/Router.swift
@@ -16,7 +16,7 @@ import SwiftyJSON
  **/
 public enum Router {
 
-    public typealias Id = Int
+    public typealias Id = String
     public typealias Params = [String: Any]?
 
     /**


### PR DESCRIPTION
Currently the ID parameter for Strava objects is a typealias to Int in Router.swift. However ID for Strava `Gear` (aka `Equipment`) is a String, so the `gear` API call does not work. ID is not used in any arithmetic and is simply passed around and interpolated into a string for the Strava API calls so the library operation is not impacted by this change. 
This change also adds a `gear_id` (String) attribute to the `Activity` class which was missing before

This is a breaking change for programs calling the `request` API function with an embedded `route` parameter as the `id` parameter to `Router` has changed from `Int` to `String`. However the fix is a simple interpolation (`id: id` becomes `id: "\(id)"`